### PR TITLE
Relax upperbound of deepseq version

### DIFF
--- a/bencoding.cabal
+++ b/bencoding.cabal
@@ -41,7 +41,7 @@ library
   build-depends:       base       == 4.*
                      , ghc-prim
                      , integer-gmp
-                     , deepseq    == 1.3.*
+                     , deepseq    >= 1.3
 
                      , mtl
 


### PR DESCRIPTION
`GHC 7.10` is bundled with `deepseq 1.4.*` now. There is some API incompatibility but it doesn't affect the use in `bencoding`.
